### PR TITLE
Add workaround for https://github.com/gradle/gradle/issues/26020

### DIFF
--- a/build-logic/project/settings.gradle.kts
+++ b/build-logic/project/settings.gradle.kts
@@ -12,6 +12,17 @@ plugins {
     id("ru.pixnews.sqlite.open.helper.gradle.settings.root")
 }
 
+// Workaround for https://github.com/gradle/gradle/issues/26020
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$embeddedKotlinVersion")
+    }
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/build-logic/settings/settings.gradle.kts
+++ b/build-logic/settings/settings.gradle.kts
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Workaround for https://github.com/gradle/gradle/issues/26020
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$embeddedKotlinVersion")
+    }
+}
+
 dependencyResolutionManagement {
     repositories.gradlePluginPortal()
     versionCatalogs {


### PR DESCRIPTION
Kotlin tasks stay up-to-date when libs.versions.toml file is modified